### PR TITLE
Hide personal expense menus in shared mode

### DIFF
--- a/src/app/core/navbar/navbar.component.html
+++ b/src/app/core/navbar/navbar.component.html
@@ -13,35 +13,34 @@
         <span class="d-md-none d-lg-inline" i18n>Inicio</span>
       </a>
     </li>
-    @if (!isPersonalMode()) {
-      <li class="nav-item">
-        <a routerLink="/debts" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-link">
-          <mat-icon>dashboard</mat-icon>
-          <span class="d-md-none d-lg-inline" i18n>Deudas</span>
-        </a>
-      </li>
-    }
+
     <li class="nav-item">
       <a [routerLink]="expenseDetailsLink()" routerLinkActive="active" class="nav-link">
         <mat-icon>receipt_long</mat-icon>
         <span class="d-md-none d-lg-inline" i18n>Gastos</span>
       </a>
     </li>
-    @if (!isPersonalMode()) {
+
+    @if (isPersonalMode()) {
+      <li class="nav-item">
+        <a routerLink="/personal" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-link">
+          <mat-icon>person</mat-icon>
+          <span class="d-md-none d-lg-inline" i18n>Personal</span>
+        </a>
+      </li>
+    } @else {
+      <li class="nav-item">
+        <a routerLink="/debts" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-link">
+          <mat-icon>dashboard</mat-icon>
+          <span class="d-md-none d-lg-inline" i18n>Deudas</span>
+        </a>
+      </li>
       <li class="nav-item">
         <a routerLink="/stats" routerLinkActive="active" class="nav-link">
           <mat-icon>analytics</mat-icon>
           <span class="d-md-none d-lg-inline" i18n>Reportes</span>
         </a>
       </li>
-    }
-    <li class="nav-item">
-      <a routerLink="/personal" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-link">
-        <mat-icon>person</mat-icon>
-        <span class="d-md-none d-lg-inline" i18n>Personal</span>
-      </a>
-    </li>
-    @if (!isPersonalMode()) {
       <li class="nav-item">
         <a routerLink="/expense" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-link">
           <mat-icon>group</mat-icon>
@@ -55,6 +54,7 @@
         </a>
       </li>
     }
+
     <li class="nav-item">
       <a routerLink="/forecast" routerLinkActive="active" [class.disabled]="!weatherActive()" class="nav-link">
         <mat-icon>wb_sunny</mat-icon>


### PR DESCRIPTION
This change ensures that menu items related to personal expenses are hidden when the user is in shared expenses mode, and vice versa. It improves the user experience by only showing relevant navigation options for the selected context.

Key changes:
- Modified `src/app/core/navbar/navbar.component.html` to use `@if (isPersonalMode())` for mode-specific menu visibility.
- Grouped shared-mode only items ('Deudas', 'Reportes', 'Grupal', 'Usuarios') under the `@else` block.
- Verified changes using Playwright automated scripts and manual inspection of screenshots/video.
- Ensured environment cleanliness by removing temporary logs and scripts before submission.

---
*PR created automatically by Jules for task [3483002511279281677](https://jules.google.com/task/3483002511279281677) started by @chdelucia*